### PR TITLE
refine dollar syntax

### DIFF
--- a/Cirru.YAML-tmLanguage
+++ b/Cirru.YAML-tmLanguage
@@ -19,20 +19,20 @@ patterns:
 - name: keyword.operator.cirru
   match: (?=^)\s*\,
 
-- name: support.function.cirru
-  match: (?=^)\s*[^\(\)\s\$][^\(\)\s]*
-
-- name: support.function.cirru
-  match: (?<=\()[^\(\)\s\$][^\(\)\s]*
-
-- name: support.function.cirru
-  match: (?=\$\s+)[^\(\)\s\$][^\(\)\s]*
-
 - name: keyword.operator.cirru
   match: \s\$\s*$
 
+- name: support.function.cirru
+  match: (?=^)\s*[^\(\)\s][^\(\)\s]*
+
+- name: support.function.cirru
+  match: (?<=\()[^\(\)\s][^\(\)\s]*
+
+- name: support.function.cirru
+  match: (?=\$\s+)[^\(\)\s][^\(\)\s]*
+
 - name: entity.cirru
-  match: \s+((\$\s+)+)([^\(\)\s\$][^\(\)\s]*)
+  match: \s+((\$\s+)+)([^\(\)\s][^\(\)\s]*)
   captures:
     '1': {name: keyword.operator.cirru}
     '3': {name: support.function.cirru}
@@ -41,4 +41,4 @@ patterns:
   match: '[\)\(]'
 
 - name: variable.parameter.cirru
-  match: (?!=($\s+))[^\(\)\s\$][^\(\)\s]*
+  match: (?!=($\s+))[^\(\)\s][^\(\)\s]*

--- a/Cirru.tmLanguage
+++ b/Cirru.tmLanguage
@@ -42,27 +42,27 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?=^)\s*[^\(\)\s\$][^\(\)\s]*</string>
-			<key>name</key>
-			<string>support.function.cirru</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?&lt;=\()[^\(\)\s\$][^\(\)\s]*</string>
-			<key>name</key>
-			<string>support.function.cirru</string>
-		</dict>
-		<dict>
-			<key>match</key>
-			<string>(?=\$\s+)[^\(\)\s\$][^\(\)\s]*</string>
-			<key>name</key>
-			<string>support.function.cirru</string>
-		</dict>
-		<dict>
-			<key>match</key>
 			<string>\s\$\s*$</string>
 			<key>name</key>
 			<string>keyword.operator.cirru</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?=^)\s*[^\(\)\s][^\(\)\s]*</string>
+			<key>name</key>
+			<string>support.function.cirru</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?&lt;=\()[^\(\)\s][^\(\)\s]*</string>
+			<key>name</key>
+			<string>support.function.cirru</string>
+		</dict>
+		<dict>
+			<key>match</key>
+			<string>(?=\$\s+)[^\(\)\s][^\(\)\s]*</string>
+			<key>name</key>
+			<string>support.function.cirru</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -79,7 +79,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\s+((\$\s+)+)([^\(\)\s\$][^\(\)\s]*)</string>
+			<string>\s+((\$\s+)+)([^\(\)\s][^\(\)\s]*)</string>
 			<key>name</key>
 			<string>entity.cirru</string>
 		</dict>
@@ -91,7 +91,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?!=($\s+))[^\(\)\s\$][^\(\)\s]*</string>
+			<string>(?!=($\s+))[^\(\)\s][^\(\)\s]*</string>
 			<key>name</key>
 			<string>variable.parameter.cirru</string>
 		</dict>


### PR DESCRIPTION
`$a` is different from `$`, and can be used to represent a simple token now.
